### PR TITLE
Created new networking crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -1052,6 +1053,7 @@ dependencies = [
  "bevy_math",
  "bevy_reflect",
  "bevy_utils",
+ "serde",
  "thiserror",
 ]
 
@@ -1556,6 +1558,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_utils",
  "crossbeam-channel",
+ "serde",
  "thiserror",
 ]
 
@@ -1570,6 +1573,7 @@ dependencies = [
  "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
+ "serde",
  "thiserror",
 ]
 
@@ -1673,6 +1677,7 @@ dependencies = [
  "bevy_reflect",
  "bevy_utils",
  "raw-window-handle",
+ "serde",
 ]
 
 [[package]]
@@ -5445,6 +5450,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "social-networking"
+version = "0.0.0"
+dependencies = [
+ "bevy",
+ "color-eyre",
+ "derive_more",
+ "lightyear",
+ "portpicker",
+ "random-number",
+ "serde",
+ "tracing",
+]
+
+[[package]]
 name = "social-server"
 version = "0.0.0"
 dependencies = [
@@ -5455,6 +5474,7 @@ dependencies = [
  "color-eyre",
  "lightyear",
  "social-common",
+ "social-networking",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
 	"apps/rvid/client",
 	"apps/rvid/server",
 	"apps/social/client",
+	"apps/social/networking",
 	"apps/social/server",
 	"apps/social/common",
 
@@ -23,24 +24,26 @@ rust-version = "1.74.1"
 
 [workspace.dependencies]
 bevy = "0.12"
-bevy_oxr = { git = "https://github.com/awtterpip/bevy_oxr", rev = "265696b", default-features = false }
-color-eyre = "0.6"
-eyre = "0.6"
-openxr = "0.17"
-bevy_mod_inverse_kinematics = "0.5"
-bevy_egui = "0.23"
-egui = "0.23"
 bevy-inspector-egui = "0.21.0"
-bevy_web_asset = { git = "https://github.com/johanhelsing/bevy_web_asset"}
-bevy_vrm = "0.0.7"
-social-common.path = "apps/social/common"
-lightyear = "0.5.1"
-serde = "1.0.193"
-clap = { version = "4.4.11", features = ["derive"] }
+bevy_egui = "0.23"
+bevy_mod_inverse_kinematics = "0.5"
 bevy_mod_picking = "0.17.0"
 bevy_mod_raycast = "0.16.0"
+bevy_oxr = { git = "https://github.com/awtterpip/bevy_oxr", rev = "265696b", default-features = false }
 bevy_picking_core = "0.17.0"
+bevy_vrm = "0.0.7"
+bevy_web_asset = { git = "https://github.com/johanhelsing/bevy_web_asset"}
+clap = { version = "4.4.11", features = ["derive"] }
+color-eyre = "0.6"
 derive_more = { version = "0.99", features = ["add", "mul"] }
+egui = "0.23"
+eyre = "0.6"
+lightyear = "0.5.1"
+openxr = "0.17"
+random-number = "0.1.8"
+serde = "1.0.193"
+social-common.path = "apps/social/common"
+social-networking.path = "apps/social/networking"
 tracing = "0.1.40"
 
 [profile.dev]

--- a/apps/social/client/Cargo.toml
+++ b/apps/social/client/Cargo.toml
@@ -12,18 +12,18 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bevy = { workspace = true, features = ["dynamic_linking"] }
-bevy_oxr = { workspace = true, default-features = false }
-color-eyre.workspace = true
-openxr.workspace = true
 bevy_mod_inverse_kinematics.workspace = true 
-bevy_web_asset.workspace = true
+bevy_oxr = { workspace = true, default-features = false }
 bevy_vrm.workspace = true
-lightyear.workspace = true
-social-common.workspace = true
-portpicker = "0.1.1"
-random-number = "0.1.8"
+bevy_web_asset.workspace = true
+color-eyre.workspace = true
 cpal = "0.15.2"
+lightyear.workspace = true
+openxr.workspace = true
+portpicker = "0.1.1"
+random-number.workspace = true
 rodio = "0.17.3"
+social-common.workspace = true
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 egui.workspace = true

--- a/apps/social/common/Cargo.toml
+++ b/apps/social/common/Cargo.toml
@@ -6,8 +6,6 @@ repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 lightyear.workspace = true
 bevy.workspace = true

--- a/apps/social/common/src/lib.rs
+++ b/apps/social/common/src/lib.rs
@@ -116,6 +116,7 @@ pub struct Channel1;
 
 #[derive(Channel)]
 pub struct AudioChannel;
+
 // Messages
 
 #[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/apps/social/networking/Cargo.toml
+++ b/apps/social/networking/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "social-networking"
+version.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+bevy = { workspace = true, features = ["serialize"] }
+color-eyre.workspace = true
+derive_more.workspace = true
+lightyear.workspace = true
+portpicker = "0.1.1"
+random-number.workspace = true
+serde.workspace = true
+tracing.workspace = true

--- a/apps/social/networking/src/client.rs
+++ b/apps/social/networking/src/client.rs
@@ -1,0 +1,75 @@
+//! Lightyear Client that synchronizes the data model with the server.
+
+use std::{
+	net::{Ipv4Addr, SocketAddr},
+	time::Duration,
+};
+
+use bevy::prelude::{Name, Plugin};
+use lightyear::prelude::{
+	client::{
+		Authentication, ClientConfig, InputConfig, InterpolationConfig,
+		InterpolationDelay, PluginConfig, PredictionConfig, SyncConfig,
+	},
+	ClientId, Io, IoConfig, LinkConditionerConfig, PingConfig, TransportConfig,
+};
+
+use crate::{
+	data_model::{register_types, DataModelRoot},
+	lightyear::{protocol, shared_config},
+	server::{KEY, PROTOCOL_ID},
+	Transports,
+};
+
+pub const DEFAULT_PORT: u16 = 2234;
+
+pub struct ClientPlugin {
+	pub server_addr: SocketAddr,
+	pub transport: Transports,
+}
+
+impl Plugin for ClientPlugin {
+	fn build(&self, app: &mut bevy::prelude::App) {
+		register_types(app);
+		let root_entity = app.world.spawn(Name::new("DataModelRoot")).id();
+		app.insert_resource(DataModelRoot(root_entity));
+
+		let client_id: u16 = random_number::random!(); // Larger values overflow
+		let client_port = portpicker::pick_unused_port().unwrap_or(DEFAULT_PORT);
+		let auth = Authentication::Manual {
+			server_addr: self.server_addr,
+			client_id: client_id as ClientId,
+			private_key: KEY,
+			protocol_id: PROTOCOL_ID,
+		};
+		let client_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), client_port);
+		let link_conditioner = LinkConditionerConfig {
+			incoming_latency: Duration::from_millis(100),
+			incoming_jitter: Duration::from_millis(5),
+			incoming_loss: 0.001,
+		};
+		let transport = match self.transport {
+			Transports::Udp => TransportConfig::UdpSocket(client_addr),
+		};
+		let io = Io::from_config(
+			&IoConfig::from_transport(transport).with_conditioner(link_conditioner),
+		);
+		let config = ClientConfig {
+			shared: shared_config().clone(),
+			input: InputConfig::default(),
+			netcode: Default::default(),
+			ping: PingConfig::default(),
+			sync: SyncConfig::default(),
+			prediction: PredictionConfig::default(),
+			// we are sending updates every frame (60fps), let's add a delay of 6 network-ticks
+			interpolation: InterpolationConfig::default().with_delay(
+				InterpolationDelay::default().with_send_interval_ratio(2.0),
+			),
+			// .with_delay(InterpolationDelay::Ratio(2.0)),
+		};
+		let plugin_config = PluginConfig::new(config, io, protocol(), auth);
+		app.add_plugins(::lightyear::client::plugin::ClientPlugin::new(
+			plugin_config,
+		));
+	}
+}

--- a/apps/social/networking/src/data_model/mod.rs
+++ b/apps/social/networking/src/data_model/mod.rs
@@ -1,0 +1,60 @@
+mod player_pose;
+
+pub(crate) use self::player_pose::PlayerPoseInterp;
+pub use self::player_pose::{Isometry, PlayerPose};
+
+use bevy::{
+	prelude::{App, Color, Component, Entity, Resource},
+	reflect::Reflect,
+};
+use lightyear::prelude::{client::InterpolatedComponent, Message};
+use serde::{Deserialize, Serialize};
+
+/// All data in the data model has this entity as its ancestor.
+#[derive(Resource, Reflect, Debug)]
+pub struct DataModelRoot(pub Entity);
+
+/// Auto-increments for each player that connects.
+#[derive(
+	Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect,
+)]
+pub struct PlayerId(u16);
+
+#[derive(
+	Component, Message, Deserialize, Serialize, Clone, Debug, PartialEq, Reflect,
+)]
+pub struct PlayerColor(pub Color);
+
+#[derive(
+	Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect,
+)]
+pub struct PlayerAvatarUrl(pub Option<String>);
+
+#[derive(
+	Component, Message, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect,
+)]
+pub struct NetworkedSpatialAudio(pub Option<Vec<f32>>);
+
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect)]
+pub struct MicrophoneAudio(pub Vec<f32>);
+
+#[derive(Message, Serialize, Deserialize, Clone, Debug, PartialEq, Reflect)]
+pub struct ServerToClientMicrophoneAudio(pub Vec<f32>, pub u64);
+
+pub(crate) fn register_types(app: &mut App) {
+	app.register_type::<DataModelRoot>()
+		.register_type::<MicrophoneAudio>()
+		.register_type::<NetworkedSpatialAudio>()
+		.register_type::<PlayerAvatarUrl>()
+		.register_type::<PlayerColor>()
+		.register_type::<ServerToClientMicrophoneAudio>()
+		.register_type::<PlayerId>();
+}
+
+// ---- type checks ----
+
+fn _assert_impl_interp() {
+	fn check<T: InterpolatedComponent<T>>() {}
+
+	check::<PlayerPose>()
+}

--- a/apps/social/networking/src/data_model/player_pose.rs
+++ b/apps/social/networking/src/data_model/player_pose.rs
@@ -1,0 +1,61 @@
+use bevy::{
+	prelude::{Component, Quat, Vec3},
+	reflect::Reflect,
+};
+use lightyear::prelude::{client::InterpFn, Message};
+use serde::{Deserialize, Serialize};
+
+#[derive(
+	Component,
+	Message,
+	Serialize,
+	Deserialize,
+	Clone,
+	Debug,
+	PartialEq,
+	Default,
+	Reflect,
+)]
+pub struct PlayerPose {
+	pub head: Isometry,
+	pub hand_l: Isometry,
+	pub hand_r: Isometry,
+}
+
+/// An isometry is like a `Transform`, but without scale.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, Reflect)]
+pub struct Isometry {
+	pub trans: Vec3,
+	pub rot: Quat,
+}
+
+/// Interpolates between two [`PlayerPose`]s.
+pub struct PlayerPoseInterp;
+
+impl InterpFn<PlayerPose> for PlayerPoseInterp {
+	fn lerp(mut start: PlayerPose, other: PlayerPose, t: f32) -> PlayerPose {
+		/// Mutates `start` for every specified field.
+		macro_rules! call_interp {
+			($start:ident, $other:ident, $t:ident, [$($field:ident),+]) => {
+                $(
+                    $start.$field = IsometryInterp::lerp($start.$field, $other.$field, $t);
+                )+
+            };
+		}
+		call_interp!(start, other, t, [head, hand_l, hand_r]);
+
+		start
+	}
+}
+
+/// Interpolates between two [`Isometry`]s.
+struct IsometryInterp;
+
+impl InterpFn<Isometry> for IsometryInterp {
+	fn lerp(mut start: Isometry, other: Isometry, t: f32) -> Isometry {
+		start.trans = start.trans.lerp(other.trans, t);
+		start.rot = start.rot.lerp(other.rot, t);
+
+		start
+	}
+}

--- a/apps/social/networking/src/lib.rs
+++ b/apps/social/networking/src/lib.rs
@@ -1,0 +1,16 @@
+//! The networking crate. This is a separate crate to ensure that its contents are as
+//! isolated from the client and server code as possible.
+
+pub mod data_model;
+
+mod client;
+mod lightyear;
+mod server;
+
+pub use crate::client::ClientPlugin;
+pub use crate::server::ServerPlugin;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Transports {
+	Udp,
+}

--- a/apps/social/networking/src/lightyear.rs
+++ b/apps/social/networking/src/lightyear.rs
@@ -1,0 +1,87 @@
+//! The networking data model.
+
+use std::time::Duration;
+
+use lightyear::{
+	prelude::{
+		component_protocol, message_protocol, Channel, ChannelDirection, ChannelMode,
+		ChannelSettings, LogConfig, ReliableSettings, SharedConfig, TickConfig,
+		UserInput,
+	},
+	protocol::Protocol,
+	protocolize,
+};
+use serde::{Deserialize, Serialize};
+use tracing::Level;
+
+use super::data_model;
+use data_model::PlayerPoseInterp;
+
+protocolize! {
+	Self = MyProtocol,
+	Message = Messages,
+	Component = Components,
+	Input = Inputs,
+}
+
+#[message_protocol(protocol = "MyProtocol")]
+pub enum Messages {
+	MicrophoneAudio(data_model::MicrophoneAudio),
+	ServerToClientMicrophoneAudio(data_model::ServerToClientMicrophoneAudio),
+}
+
+#[component_protocol(protocol = "MyProtocol")]
+pub enum Components {
+	#[sync(once)]
+	PlayerId(data_model::PlayerId),
+	#[sync(full, lerp = PlayerPoseInterp)]
+	PlayerPose(data_model::PlayerPose),
+	#[sync(once)]
+	PlayerColor(data_model::PlayerColor),
+	#[sync(simple)]
+	PlayerAvatarUrl(data_model::PlayerAvatarUrl),
+	#[sync(simple)]
+	NetworkedSpatialAudio(data_model::NetworkedSpatialAudio),
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum Inputs {}
+
+impl UserInput for Inputs {}
+
+// Channels
+
+#[derive(Channel)]
+pub struct Channel1;
+
+#[derive(Channel)]
+pub struct AudioChannel;
+
+pub fn protocol() -> MyProtocol {
+	let mut protocol = MyProtocol::default();
+	protocol.add_channel::<Channel1>(ChannelSettings {
+		mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+		direction: ChannelDirection::Bidirectional,
+	});
+	protocol.add_channel::<AudioChannel>(ChannelSettings {
+		mode: ChannelMode::OrderedReliable(ReliableSettings::default()),
+		direction: ChannelDirection::Bidirectional,
+	});
+	protocol
+}
+
+pub fn shared_config() -> SharedConfig {
+	SharedConfig {
+        enable_replication: true,
+        client_send_interval: Duration::default(),
+        server_send_interval: Duration::from_millis(100),
+        tick: TickConfig {
+            tick_duration: Duration::from_secs_f64(1.0 / 64.0),
+        },
+        log: LogConfig {
+            level: Level::INFO,
+            filter: "wgpu=error,wgpu_hal=error,naga=warn,bevy_app=info,bevy_render=warn,quinn=warn"
+                .to_string(),
+        },
+    }
+}

--- a/apps/social/networking/src/server.rs
+++ b/apps/social/networking/src/server.rs
@@ -1,0 +1,62 @@
+//! Lightyear Client that synchronizes the data model with the server.
+
+use std::{
+	net::{Ipv4Addr, SocketAddr},
+	time::Duration,
+};
+
+use bevy::prelude::{App, Name, Plugin};
+use lightyear::{
+	prelude::{Io, IoConfig, Key, LinkConditionerConfig, PingConfig, TransportConfig},
+	server::{
+		config::{NetcodeConfig, ServerConfig},
+		plugin::PluginConfig,
+	},
+};
+
+use crate::{
+	data_model::{register_types, DataModelRoot},
+	lightyear::{protocol, shared_config},
+	Transports,
+};
+
+pub const PROTOCOL_ID: u64 = 0;
+pub const KEY: Key = [0; 32];
+
+pub struct ServerPlugin {
+	pub port: u16,
+	pub transport: Transports,
+}
+
+impl Plugin for ServerPlugin {
+	fn build(&self, app: &mut App) {
+		register_types(app);
+		let root_entity = app.world.spawn(Name::new("DataModelRoot")).id();
+		app.insert_resource(DataModelRoot(root_entity));
+
+		let server_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), self.port);
+		let netcode_config = NetcodeConfig::default()
+			.with_protocol_id(PROTOCOL_ID)
+			.with_key(KEY);
+		let link_conditioner = LinkConditionerConfig {
+			incoming_latency: Duration::from_millis(100),
+			incoming_jitter: Duration::from_millis(10),
+			incoming_loss: 0.00,
+		};
+		let transport = match self.transport {
+			Transports::Udp => TransportConfig::UdpSocket(server_addr),
+		};
+		let io = Io::from_config(
+			&IoConfig::from_transport(transport).with_conditioner(link_conditioner),
+		);
+		let config = ServerConfig {
+			shared: shared_config().clone(),
+			netcode: netcode_config,
+			ping: PingConfig::default(),
+		};
+		let plugin_config = PluginConfig::new(config, io, protocol());
+		app.add_plugins(::lightyear::server::plugin::ServerPlugin::new(
+			plugin_config,
+		));
+	}
+}

--- a/apps/social/server/Cargo.toml
+++ b/apps/social/server/Cargo.toml
@@ -8,10 +8,11 @@ rust-version.workspace = true
 description = "A server for the social vr bevy demo"
 
 [dependencies]
-lightyear.workspace = true
-social-common.workspace = true
 bevy = { workspace = true, features = ["dynamic_linking"] }
 bevy_vrm.workspace = true
 bevy_web_asset.workspace = true
 clap.workspace = true
 color-eyre.workspace = true
+lightyear.workspace = true
+social-common.workspace = true
+social-networking.workspace = true

--- a/apps/social/server/src/lib.rs
+++ b/apps/social/server/src/lib.rs
@@ -60,10 +60,16 @@ pub fn main() -> Result<()> {
         // Third party plugins
         add_plugins(VrmPlugin)
 		// First party plugins
+        // TODO: migrate to social_networking
 		.add_plugins(MyServerPlugin {
 			port: SERVER_PORT,
 			transport: Transports::Udp,
 		})
+        // TODO: Finish functionality for this plugin and replace the above
+		// .add_plugins(::social_networking::ServerPlugin {
+		// 	port: SERVER_PORT,
+		// 	transport: ::social_networking::Transports::Udp,
+		// })
         .add_plugins(Avatars)
         .add_plugins(PlayerManagement)
         .add_plugins(if !args.frame_timings {


### PR DESCRIPTION
This is incomplete and a work in progress. The goal is to create a new, separate networking crate which has client and server plugins. Each plugin is responsible for syncing a data model, which is public and can be queried for in plugins outside of the Client/Server plugin.

There should be one parent entity which represents the "namespace" for the synchronized entities (so that inspection is easy). 

This crate is not finished yet, but I'm submitting this code so that @MalekiRe can merge it and port his old client/server code to it.