### PR TITLE
Implemented flush function, without remote changes considered.

### DIFF
--- a/crates/replicate/common/Cargo.toml
+++ b/crates/replicate/common/Cargo.toml
@@ -14,7 +14,7 @@ pin-project.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false }
-tokio-serde.workspace = true
-tokio-util.workspace = true
-url.workspace = true
+tokio-serde = { workspace = true, features = ["json"] }
+tokio-util = { workspace = true, features = ["codec"] }
+url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "serde"] }

--- a/crates/replicate/common/src/data_model/mod.rs
+++ b/crates/replicate/common/src/data_model/mod.rs
@@ -108,6 +108,14 @@ pub struct LocalChanges {
 /// The *pending* version of [`LocalChanges`]. These are built up internally as the
 /// local data model is mutated. At any time, the data model can be flushed and
 /// [`PendingLocalChanges`] are converted to [`LocalChanges`].
+///
+/// The reason that we have this type in addition to [`LocalChanges`] is because
+/// [`PendingLocalChanges`] refers to the states in the data model and therefore to
+/// read the value of a mutated entity's state requires access to [`DataModel::data`],
+/// whereas [`LocalChanges`] is self-contained and doesn't require any access to the
+/// [`DataModel`]. It is important for [`LocalChanges`] to be self-contained because it
+/// is going to be sent to a separate task and won't necessarily have read access
+/// anymore to the overall data model.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 struct PendingLocalChanges {
 	spawns: EntityMap<State>,
@@ -198,6 +206,8 @@ impl DataModel {
 		let deleted_data = self.data.remove(&entity).ok_or(EntityNotPresent)?;
 		let insert_result = self.pending.despawns.insert(entity, deleted_data.state);
 		debug_assert!(insert_result.is_none(), "sanity: can't despawn twice");
+		// No point sending mutations when we already send despawn state
+		self.pending.mutations.remove(&entity);
 
 		Ok(())
 	}
@@ -475,109 +485,119 @@ mod test_dm {
 
 	#[test]
 	fn test_flush_no_remote() {
-		fn compare_pending_to_local(dm: &DataModel, local: &LocalChanges) {
+		fn assert_dm_matches_local(dm: &DataModel, expected_local: &LocalChanges) {
 			let pending = &dm.pending;
 			// Sanity check, make sure that pending and data model are consistent.
-			pending.spawns.iter().for_each(|(&entity, bytes)| {
-				assert_eq!(bytes, dm.get(entity).unwrap(), "entity {entity:?}")
-			});
+			pending
+				.spawns
+				.iter()
+				// Only check for existence on items that weren't despawned
+				.filter(|(e, _bytes)| !pending.despawns.contains_key(e))
+				.for_each(|(&entity, _bytes)| {
+					assert!(dm.get(entity).is_ok(), "entity {entity:?}");
+				});
 			pending.despawns.iter().for_each(|(&entity, _bytes)| {
-				assert!(
-					matches!(dm.get(entity), Err(EntityNotPresent)),
-					"entity {entity:?}"
-				)
+				assert_eq!(dm.get(entity), Err(EntityNotPresent), "entity {entity:?}");
 			});
 			pending.mutations.iter().for_each(|(&entity, _mutation)| {
 				assert!(dm.get(entity).is_ok(), "entity {entity:?}")
 			});
 
-			// Actually compare pending to local
-			assert_eq!(pending.spawns, local.spawns);
-			assert_eq!(pending.despawns, local.despawns);
-			assert_eq!(pending.mutations.len(), local.mutations.len());
+			// Actually compare pending to expected
+			assert_eq!(pending.spawns, expected_local.spawns);
+			assert_eq!(pending.despawns, expected_local.despawns);
+			assert_eq!(pending.mutations.len(), expected_local.mutations.len());
 			pending.mutations.iter().for_each(|(&entity, &mutation)| {
-				let l_entry = &local.mutations[&entity];
+				let l_entry = &expected_local.mutations[&entity];
 				assert_eq!(l_entry.0, mutation, "entity: {entity:?}");
 				assert_eq!(l_entry.1, dm.get(entity).unwrap(), "entity: {entity:?}");
 			});
-		}
 
-		/// What we hard-code our expectation of the computed `LocalChanges` to be.
-		struct ExpectedLocalChanges(LocalChanges);
-
-		/// Used to easily re-run steps of the test.
-		struct Steps {
-			dm: DataModel,
-			states: Vec<State>,
-			entities: Vec<Entity>,
-		}
-
-		impl Steps {
-			fn new() -> Self {
-				Self {
-					dm: DataModel::new(),
-					states: Vec::new(),
-					entities: Vec::new(),
-				}
-			}
-
-			fn step0(&mut self) -> ExpectedLocalChanges {
-				let s0 = State::from_static(&[0]);
-				let e0 = self.dm.spawn(s0.clone());
-				self.states.push(s0.clone());
-				self.entities.push(e0);
-				let expected_local = ExpectedLocalChanges(LocalChanges {
-					spawns: HashMap::from([(e0, s0.clone())]),
-					..Default::default()
-				});
-				compare_pending_to_local(&self.dm, &expected_local.0);
-				expected_local
-			}
-
-			fn step1(&mut self) -> ExpectedLocalChanges {
-				self.step0();
-				let s0 = self.states[0].clone();
-				let e0 = self.entities[0];
-				let s1 = State::from_static(&[1]);
-				let e1 = self.dm.spawn(s1.clone());
-				self.states.push(s1.clone());
-				self.entities.push(e1);
-				let expected_local = ExpectedLocalChanges(LocalChanges {
-					spawns: HashMap::from([(e0, s0), (e1, s1)]),
-					..Default::default()
-				});
-				compare_pending_to_local(&self.dm, &expected_local.0);
-				expected_local
-			}
-
-			// TODO: Try deleting and updating entities next
-
-			fn reset(&mut self) {
-				std::mem::take(self);
-			}
-		}
-
-		impl Default for Steps {
-			fn default() -> Self {
-				Self::new()
-			}
-		}
-
-		let mut steps = Steps::new();
-		let remote = RemoteChanges::default();
-		let mut local = LocalChanges::default();
-
-		macro_rules! do_step {
-			($steps:expr, $step:tt) => {
-				$steps.reset();
-				let expected = $steps.$step();
-				steps.dm.flush(&remote, &mut local);
-				assert_eq!(expected.0, local);
+			// compare data model states to expected
+			let expected_states = {
+				let mut states = expected_local.spawns.clone();
+				states.extend(
+					expected_local
+						.mutations
+						.iter()
+						.map(|(&e, (_state_mutation, bytes))| (e, bytes.clone())),
+				);
+				states.retain(|e, _bytes| !expected_local.despawns.contains_key(e));
+				states
 			};
+			assert_eq!(dm.data.len(), expected_states.len());
+			for (e, entity_data) in dm.data.iter() {
+				assert_eq!(entity_data.state, expected_states[&e], "entity: {e:?}");
+			}
 		}
 
-		do_step!(steps, step0);
-		do_step!(steps, step1);
+		let mut dm = DataModel::default();
+		let mut expected_local = LocalChanges::default();
+
+		fn check(dm: &DataModel, expected_local: &LocalChanges) {
+			assert_dm_matches_local(dm, expected_local);
+			let mut local_from_flush = LocalChanges::default();
+			let remote = RemoteChanges::default();
+			// Clone to avoid clearing pending local changes from datamodel needed in later steps.
+			dm.clone().flush(&remote, &mut local_from_flush);
+			assert_eq!(&local_from_flush, expected_local);
+		}
+
+		// Spawn e0
+		let s0_a = State::from_static(b"s0_a");
+		let e0 = dm.spawn(s0_a.clone());
+		expected_local.spawns.insert(e0, s0_a.clone());
+		check(&dm, &expected_local);
+
+		// Spawn e1
+		let s1_a = State::from_static(b"s1_a");
+		let e1 = dm.spawn(s1_a.clone());
+		assert_eq!(dm.get(e1).unwrap(), &s1_a);
+		expected_local.spawns.insert(e1, s1_a);
+		check(&dm, &expected_local);
+
+		// Update e0 unreliably
+		let s0_b = State::from_static(b"s0_b");
+		dm.update(e0, s0_b.clone()).unwrap();
+		expected_local
+			.mutations
+			.insert(e0, (StateMutation::Unreliable, s0_b));
+		check(&dm, &expected_local);
+
+		// Update e0 reliably
+		let s0_c = State::from_static(b"s0_c");
+		dm.update_reliable(e0, s0_c.clone()).unwrap();
+		// Unreliable overwritten with Reliable, along with state.
+		expected_local
+			.mutations
+			.insert(e0, (StateMutation::Reliable, s0_c));
+		check(&dm, &expected_local);
+
+		// Update e0 unreliably
+		let s0_d = State::from_static(b"s0_d");
+		dm.update(e0, s0_d.clone()).unwrap();
+		// Reliable is not overwritten, but the state is.
+		expected_local
+			.mutations
+			.insert(e0, (StateMutation::Reliable, s0_d.clone()));
+		check(&dm, &expected_local);
+
+		// Update e1 unreliably
+		let s1_b = State::from_static(b"s1_b");
+		dm.update(e1, s1_b.clone()).unwrap();
+		expected_local
+			.mutations
+			.insert(e1, (StateMutation::Unreliable, s1_b));
+		check(&dm, &expected_local);
+
+		// Despawn e0
+		dm.despawn(e0).unwrap();
+		// The mutations should dissapear...
+		let state_at_despawn = expected_local.mutations.remove(&e0).unwrap().1;
+		// ...but the spawns should remain.
+		assert_eq!(expected_local.spawns[&e0], s0_a);
+		expected_local.despawns.insert(e0, state_at_despawn);
+		check(&dm, &expected_local);
 	}
 }
 


### PR DESCRIPTION
~Need to add more test steps for updating and despawning, but other than that, this is mergeable.~

Implements the flush function, although to keep the code simpler I assume that there are no remote changes yet.
Includes tests.