### PR TITLE
did-simple: fix bugs in decode related to overflow detection and test all possible varints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,7 @@ dependencies = [
  "bytes",
  "eyre",
  "hex-literal",
+ "itertools 0.13.0",
  "thiserror",
 ]
 
@@ -4672,6 +4673,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/crates/did-simple/Cargo.toml
+++ b/crates/did-simple/Cargo.toml
@@ -16,3 +16,4 @@ bs58 = "0.5.1"
 [dev-dependencies]
 eyre = "0.6.12"
 hex-literal = "0.4.1"
+itertools = "0.13.0"


### PR DESCRIPTION
As @lyuma pointed out in #100, we needed to check to make sure that no bits were truncated during the left shift. It was not sufficient to just rely on checked_shl for this.