### PR TITLE
physnet: actually connect to manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "async-compat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -6034,6 +6034,7 @@ dependencies = [
 name = "physnet_client"
 version = "0.0.0"
 dependencies = [
+ "async-compat",
  "bevy",
  "bevy-inspector-egui",
  "bevy_flycam",
@@ -6045,6 +6046,7 @@ dependencies = [
  "rand_xoshiro",
  "replicate-client",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ edition = "2021"
 rust-version = "1.78.0"
 
 [workspace.dependencies]
+async-compat = "0.2.4"
 base64 = "0.21.7"
 bevy = { version = "0.13", features = ["serialize"] }
 bevy-inspector-egui = "0.23.4"

--- a/apps/networked_physics_demo/client/Cargo.toml
+++ b/apps/networked_physics_demo/client/Cargo.toml
@@ -23,3 +23,5 @@ rand.workspace = true
 rand_xoshiro.workspace = true
 replicate-client.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
+async-compat.workspace = true

--- a/apps/networked_physics_demo/client/src/netcode.rs
+++ b/apps/networked_physics_demo/client/src/netcode.rs
@@ -5,47 +5,110 @@ use bevy::{
 	ecs::{
 		component::Component,
 		entity::Entity,
-		event::{Event, EventReader},
+		event::{Event, EventReader, EventWriter},
 		query::{Added, With, Without},
-		schedule::NextState,
-		system::{Commands, Query, Res, ResMut, Resource},
+		system::{CommandQueue, Commands, Query, Res, ResMut, Resource},
+		world::World,
 	},
-	log::trace,
-	reflect::Reflect,
+	log::{error, trace},
+	tasks::IoTaskPool,
 	transform::components::{GlobalTransform, Transform},
 };
+use color_eyre::eyre::{Result, WrapErr as _};
 use replicate_client::common::data_model::{DataModel, Entity as DmEntity};
+use tokio::sync::mpsc;
 
-use crate::GameModeState;
+const BOUNDED_CHAN_COMMAND_QUEUE_SIZE: usize = 16;
 
-#[derive(Debug)]
-pub struct NetcodePlugin;
+#[derive(Debug, Default)]
+pub struct NetcodePlugin {}
 
 impl Plugin for NetcodePlugin {
 	fn build(&self, app: &mut bevy::prelude::App) {
-		app.register_type::<ConnectToManager>()
-			.add_event::<ConnectToManager>()
+		app.add_event::<ConnectToManagerRequest>()
+			.add_event::<ConnectToManagerResponse>()
+			.init_resource::<CommandQueueChannel>()
 			.init_resource::<NetcodeDataModel>()
-			.add_systems(PreUpdate, from_data_model)
+			.add_systems(PreUpdate, (apply_queued_commands, from_data_model))
 			.add_systems(PostUpdate, (spawn_entities, to_data_model))
 			.add_systems(Update, on_connect_to_manager_evt);
 	}
 }
 
-/// Other plugins create this when they want to connect to a manager.
-#[derive(Debug, Reflect, Event, Eq, PartialEq)]
-pub struct ConnectToManager {
-	/// The URL of the manager to connect to
-	pub manager_url: String,
+#[derive(Debug, Resource)]
+struct NetcodeManager(#[allow(unused)] replicate_client::manager::Manager);
+
+/// Convenient way to receive commands sent from the async tasks.
+#[derive(Debug, Resource)]
+struct CommandQueueChannel {
+	tx: mpsc::Sender<CommandQueue>,
+	rx: mpsc::Receiver<CommandQueue>,
 }
 
-fn on_connect_to_manager_evt(
-	mut connect_to_manager: EventReader<ConnectToManager>,
-	mut next_state: ResMut<NextState<GameModeState>>,
+impl Default for CommandQueueChannel {
+	fn default() -> Self {
+		let (tx, rx) = mpsc::channel(BOUNDED_CHAN_COMMAND_QUEUE_SIZE);
+		Self { tx, rx }
+	}
+}
+
+fn apply_queued_commands(
+	mut commands: Commands,
+	mut chan: ResMut<CommandQueueChannel>,
 ) {
-	for ConnectToManager { manager_url: _ } in connect_to_manager.read() {
-		// TODO: Actually connect to the manager instead of faking it
-		next_state.set(GameModeState::InMinecraft);
+	while let Ok(mut command_queue) = chan.rx.try_recv() {
+		commands.append(&mut command_queue)
+	}
+}
+
+/// Other plugins create this when they want to connect to a manager.
+#[derive(Debug, Event, Eq, PartialEq)]
+pub struct ConnectToManagerRequest {
+	/// The URL of the manager to connect to. If `None`, locally host.
+	pub manager_url: Option<replicate_client::url::Url>,
+}
+
+/// Produced in response to [`ConnectToManagerRequest`].
+#[derive(Debug, Event)]
+pub struct ConnectToManagerResponse(pub Result<()>);
+
+fn on_connect_to_manager_evt(
+	command_queue: Res<CommandQueueChannel>,
+	mut request: EventReader<ConnectToManagerRequest>,
+	mut response: EventWriter<ConnectToManagerResponse>,
+) {
+	for ConnectToManagerRequest { manager_url } in request.read() {
+		let Some(manager_url) = manager_url else {
+			response.send(ConnectToManagerResponse(Ok(())));
+			continue;
+		};
+		let pool = IoTaskPool::get();
+		let manager_url = manager_url.to_owned();
+		let tx = command_queue.tx.clone();
+		pool.spawn(async_compat::Compat::new(async move {
+			let connect_result =
+				replicate_client::manager::Manager::connect(manager_url, None)
+					.await
+					.wrap_err("failed to connect to manager server");
+			if let Err(ref err) = connect_result {
+				error!("{err:?}");
+			}
+
+			// We use a command queue to enqueue commands back to bevy from the
+			// async code.
+			let mut queue = CommandQueue::default();
+			let response_event = ConnectToManagerResponse(connect_result.map(|mngr| {
+				queue.push(|w: &mut World| w.insert_resource(NetcodeManager(mngr)));
+			}));
+			queue.push(|w: &mut World| {
+				w.send_event(response_event).expect("failed to send event");
+			});
+			match tx.send(queue).await {
+				Ok(()) | Err(mpsc::error::SendError(_)) => (),
+			}
+		}))
+		// We don't need to explicitly retrieve the return value.
+		.detach();
 	}
 }
 

--- a/crates/replicate/client/src/lib.rs
+++ b/crates/replicate/client/src/lib.rs
@@ -3,8 +3,10 @@ use eyre::Result;
 use tracing::warn;
 use url::Url;
 
-pub use replicate_common as common;
 use wtransport::{endpoint::ConnectOptions, ClientConfig, Endpoint};
+
+pub use replicate_common as common;
+pub use url;
 
 pub mod instance;
 pub mod manager;


### PR DESCRIPTION
I've updated the code to properly spawn a future that will start the tokio runtime and perform the necessary steps to connect to the replicate manager.

Next step will be to use the newly connected manager resource to spawn an instance. The video showcases the UI flows and how connecting to a server that doesn't exist fails, but connecting to the one I start from the command line with a valid url succeeds.

Rebased on #111 


https://github.com/NexusSocial/nexus-vr/assets/6969415/c2d1ee2f-593a-4ee4-a3a7-bd39ccdcc569

