### PR TITLE
Pool connections using bb8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -927,6 +927,18 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bb8"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10cf871f3ff2ce56432fddc2615ac7acc3aa22ca321f8fea800846fbb32f188"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
 
 [[package]]
 name = "bevy"
@@ -6667,7 +6679,9 @@ checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
 name = "replicate-client"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "base64 0.21.7",
+ "bb8",
  "bytes",
  "clap",
  "color-eyre",

--- a/crates/replicate/client/Cargo.toml
+++ b/crates/replicate/client/Cargo.toml
@@ -9,7 +9,9 @@ description = "A client api for state replication"
 publish = false
 
 [dependencies]
+async-trait = "0.1.80"
 base64.workspace = true
+bb8 = "0.8.5"
 bytes.workspace = true
 eyre.workspace = true
 futures.workspace = true


### PR DESCRIPTION
Moves from an async worker (bad abstraction) to a connection pool.

`bb8` [does not have an obvious way to kill connections involved in a panic](https://github.com/djc/bb8/issues/211), so as a (hopefully temporary) workaround, a wrapper is used that checks for panics on drop and, if so, replaces the connection with a `None` before it is returned to the pool, at which point it is identified as dead via `has_broken`.

~~Draft as~~ it compiles but is not yet tested.